### PR TITLE
POP removed the expires_in from the headers return

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ def save_token(token, request, *args, **kwargs):
     for t in toks:
         t.delete_instance()
 
-    expires_in = token.pop('expires_in')
+    expires_in = token['expires_in']
     expires = datetime.utcnow() + timedelta(seconds=expires_in)
 
     tok = OAuth2BearerToken(


### PR DESCRIPTION
The returns should include the expires_in, some clients are expecting this field. something like this 

 HTTP/1.1 200 OK
     Content-Type: application/json;charset=UTF-8
     Cache-Control: no-store
     Pragma: no-cache

     {
       "access_token":"mF_9.B5f-4.1JqM",
       "token_type":"Bearer",
       "expires_in":3600,
       "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA"
     }

the function pop remove the expires_in field.